### PR TITLE
Fix generic type to prevent undefined values

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,8 +1,8 @@
 import type { Component } from 'vue'
 
-export interface ColumnDefinition<T extends Record<string, any> | undefined = undefined> {
+export interface ColumnDefinition<T extends Record<string, any> = Record<string, any>> {
     text: string
-    data: T extends undefined ? string : keyof T
+    data: keyof T
     sortable?: boolean
     filterable?: boolean
     format?: (value: any, row: Record<string, any>) => any


### PR DESCRIPTION
Adjust the generic type in the `ColumnDefinition` interface to ensure it cannot be undefined, enhancing type safety.