### PR TITLE
Stop select event propagation in filter component

### DIFF
--- a/src/Components/DataHeader.vue
+++ b/src/Components/DataHeader.vue
@@ -37,8 +37,9 @@
                     v-if="cell.filterable"
                     :data-field="cell.data"
                     :filter="filter"
-                    @filter="onFilter"
                     :i18n="i18n"
+                    @filter="onFilter"
+                    @select.stop
                 />
             </th>
             <th v-if="actions && !actionsOnLeft"></th>


### PR DESCRIPTION
Prevent event propagation when selecting items in the filter component to improve user interaction.