### PR TITLE
Fix default row class handling

### DIFF
--- a/src/Components/DataHeader.vue
+++ b/src/Components/DataHeader.vue
@@ -65,7 +65,7 @@ const props = withDefaults(defineProps<{
     header: ColumnDefinition<TRowData>[]
     actionsOnLeft?: boolean
     actions: boolean
-    sort?: DotPaths<TRowData> | null
+    sort?: string | null
     sortDirection?: SortDirection
     filter?: Record<string, string>
     i18n: Record<string, string>

--- a/src/Components/DataRowButtons.vue
+++ b/src/Components/DataRowButtons.vue
@@ -18,8 +18,8 @@
                             'btn-disabled': disableButtons || runningActions.includes(String(button.event))
                         }
                     ]"
-                    @click.prevent="onButtonClick(button)"
                     :disabled="disableButtons"
+                    @click.prevent="onButtonClick(button)"
                 >
                     <template v-if="button.customTextComponent">
                         <component
@@ -27,7 +27,9 @@
                             v-bind="button.customTextComponentProps ?? {}"
                         />
                     </template>
-                    <template v-if="button.text">{{ button.text }}</template>
+                    <template v-if="button.text">
+                        {{ button.text }}
+                    </template>
                 </button>
                 <a
                     v-if="(!button?.customComponent && (button?.href || button?.hrefCallback))"
@@ -50,27 +52,32 @@
                     <template v-if="button.text">{{ button.text }}</template>
                 </a>
                 <component
-                    v-if="button?.customComponent"
                     :is="typeof button.customComponent === 'string' ? button.customComponent : button.customComponent()"
+                    v-if="button?.customComponent"
                     :row="row"
                     @action="onAction"
                 />
             </template>
         </div>
-        <div class="d-flex flex-wrap flex-direction-column justify-content-center align-items-center align-content-center gap-2" v-else>
-            <p class="mb-0 w-100 text-center">{{confirm.confirmText}}</p>
+        <div
+            v-else
+            class="d-flex flex-wrap flex-direction-column justify-content-center align-items-center align-content-center gap-2"
+        >
+            <p class="mb-0 w-100 text-center">
+                {{ confirm.confirmText }}
+            </p>
             <div class="d-flex justify-content-center align-content-center align-items-center flex-wrap gap-2">
                 <button
                     class="btn btn-sm btn-primary"
                     @click.prevent="onConfirm"
                 >
-                    {{i18n.buttonConfirmOk}}
+                    {{ i18n.buttonConfirmOk }}
                 </button>
                 <button
                     class="btn btn-sm btn-danger"
                     @click.prevent="onCancel"
                 >
-                    {{i18n.buttonConfirmCancel}}
+                    {{ i18n.buttonConfirmCancel }}
                 </button>
             </div>
         </div>

--- a/src/DataTable.vue
+++ b/src/DataTable.vue
@@ -216,7 +216,7 @@ const props = withDefaults(
         tableClass?: string | null
         size?: 'sm'
         autoUpdateLimit?: number
-        rowClass: string | ((row: TRowData) => null | string)
+        rowClass?: string | ((row: TRowData) => null | string)
         paginationFirstNumber?: boolean
         paginationLastNumber?: boolean
         pageOptionsVariant?: ButtonVariant
@@ -260,7 +260,8 @@ const props = withDefaults(
         autoUpdateButtonRunningVariant: undefined,
         exportButtonVariant: 'primary',
         initialDisplayConfig: undefined,
-        size: undefined
+        size: undefined,
+        rowClass: () => null
     }
 )
 

--- a/src/DataTable.vue
+++ b/src/DataTable.vue
@@ -401,18 +401,18 @@ const aggregateInitialValues = computed(() => {
     return tmp
 })
 
-const flattenedData = computed<Record<string, any>[]>(() => {
+const flattenedData = computed<TRowData[]>(() => {
     return props.data.map((item) => {
-        return flatten(item, { safe: true }) as Record<string, any>
+        return flatten(item, { safe: true })
     })
 })
 
-const filteredData = computed<Record<string, any>[]>(() => {
+const filteredData = computed<TRowData[]>(() => {
     if (props.remoteDataMode || filter.value === undefined || filter.value === null || Object.keys(filter.value).length === 0) {
         return flattenedData.value
     }
     const activeFilters = Object.keys(filter.value)
-    return flattenedData.value.filter((row: Record<string, any>) => {
+    return flattenedData.value.filter((row) => {
         let isVisible = true
         // fix for missing data property
         const rowIndexes = Object.keys(row)
@@ -440,14 +440,14 @@ const filteredData = computed<Record<string, any>[]>(() => {
     })
 })
 
-const sortedData = computed<Record<string, any>[]>(() => {
+const sortedData = computed<TRowData[]>(() => {
     if (!props.remoteDataMode && sortBy.value !== null) {
         return sortData(filteredData.value)
     }
     return filteredData.value
 })
 
-const pagedData = computed<Record<string, any>[]>(() => {
+const pagedData = computed<TRowData[]>(() => {
     if (!props.remoteDataMode && props.paging) {
         const offset = ((-1 + currentPage.value) * currentPageLimit.value)
         return getPortionOfArray(sortedData.value, offset, currentPageLimit.value)
@@ -538,7 +538,7 @@ function onExport(): void {
     $emit('export', data)
 }
 
-function processData(pagedData: Array<Record<string, any>>): ProcessedRowData<TRowData>[] {
+function processData(pagedData: Array<TRowData>): ProcessedRowData<TRowData>[] {
     return pagedData.map((row) => {
         return {
             row: unflatten(row),
@@ -547,10 +547,10 @@ function processData(pagedData: Array<Record<string, any>>): ProcessedRowData<TR
                 if (row.hasOwnProperty(item.data)) {
                     const data: ProcessedCell = { index: item.data, content: row[item.data], customComponent: (typeof item.customComponent === 'function') ? item.customComponent() : item.customComponent }
                     if (typeof item.format === 'function') {
-                        data.content = item.format(data.content, { ...row })
+                        data.content = item.format(data.content, { ...row } as any)
                     }
                     if (typeof item.cellStyle === 'function') {
-                        data.cellStyle = item.cellStyle(data.index, data.content, { ...row })
+                        data.cellStyle = item.cellStyle(data.index, data.content, { ...row } as any)
                     }
                     if (typeof item.cellStyle === 'string') {
                         data.cellStyle = item.cellStyle
@@ -567,7 +567,7 @@ function processData(pagedData: Array<Record<string, any>>): ProcessedRowData<TR
     })
 }
 
-function sortData(filteredData: Array<Record<string, any>>) {
+function sortData(filteredData: Array<TRowData>): Array<TRowData> {
     if (sortBy.value !== null) {
         const sortFn = sortFunctions.value[sortBy.value] ?? naturalSort
         if (sortFn !== null) {
@@ -579,18 +579,18 @@ function sortData(filteredData: Array<Record<string, any>>) {
     return filteredData
 }
 
-function onRowSelectToggle(row: Record<string, any>) {
+function onRowSelectToggle(row: TRowData): void {
     const options: FlattenOptions = { safe: true }
     const flatRow: Record<string, any> = flatten(row, options)
     if (selectedRowIds.value.includes(flatRow[props.selectableRowsTrackBy])) {
-        selectedRows.value = selectedRows.value.filter((item: Record<string, any>) => (flatten(item, options) as Record<string, any>)[props.selectableRowsTrackBy] !== flatRow[props.selectableRowsTrackBy])
+        selectedRows.value = selectedRows.value.filter(item => (flatten(item, options) as Record<string, any>)[props.selectableRowsTrackBy] !== flatRow[props.selectableRowsTrackBy])
     } else {
         selectedRows.value = [...selectedRows.value, row]
     }
 }
 
-function getPortionOfArray(sourceArray: Array<Record<string, any>>, offset: number, limit: number): Array<Record<string, any>> {
-    const content: Array<Record<string, any>> = []
+function getPortionOfArray(sourceArray: Array<TRowData>, offset: number, limit: number): Array<TRowData> {
+    const content: Array<TRowData> = []
     for (let i = offset; i < sourceArray.length; i++) {
         const item = sourceArray[i]
         if (item === undefined) {
@@ -644,7 +644,7 @@ function onFilter(value: Record<string, any>): void {
     filter.value = { ...cleanedFilter }
 }
 
-function onAction(value: { event: string, row: Record<string, any> }): void {
+function onAction(value: { event: string, row: TRowData }): void {
     $emit('action', value)
     // @ts-expect-error known limitation of vue uknown emits typing
     $emit(value.event, value.row)

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -26,11 +26,11 @@ export interface ColumnDefinition<
     data: DotPaths<T>
     sortable?: boolean
     filterable?: boolean
-    format?: (value: any, row: Record<string, any>) => any
+    format?: (value: any, row: ProcessedRowData<T>) => any
     sortFn?: (a: any, b: any) => number
-    filterFn?: (cellValue: any, filterValue: string, rowData: ProcessedRowData) => boolean
+    filterFn?: (cellValue: any, filterValue: string, rowData: ProcessedRowData<T>) => boolean
     customComponent?: () => Component
-    cellStyle?: string | ((index: string, content: any, row: Record<string, any>) => string | Record<string, string>)
+    cellStyle?: string | ((index: string, content: any, row: ProcessedRowData<T>) => string | Record<string, string>)
     cellClassnames?: string[]
     aggregate?: (previousValue: any, currentValue: any, currentIndex: number, array: any[]) => unknown
     aggregateInitialValue?: any


### PR DESCRIPTION
Adjust the `rowClass` property to be optional, allowing for more flexible usage in table configurations. Set a default value for `rowClass` to ensure it does not cause issues when not explicitly defined.