### PR TITLE
Reset page to 1 on filter change

### DIFF
--- a/src/DataTable.vue
+++ b/src/DataTable.vue
@@ -274,6 +274,7 @@ const currentPageLimit = ref<number>(initialPageLimit)
 const uniqueKey = ref<string>(props.tableUniqueKey ?? `vueDataTable_${generateString(20)}`)
 
 watch(filter, () => {
+    currentPage.value = 1
     onSaveState()
     onRemoteDataRefresh()
 })


### PR DESCRIPTION
Reset the current page to 1 whenever the filter changes to ensure consistent data display.