### PR TITLE
Add case sensitive filter option

### DIFF
--- a/src/DataTable.vue
+++ b/src/DataTable.vue
@@ -363,6 +363,16 @@ const filterFunctions = computed(() => {
     return tmp
 })
 
+const caseSensitiveFilters = computed(() => {
+    const tmp: Record<string, boolean> = {}
+    for (const cell of props.header) {
+        if (cell.filterCaseSensitive === true) {
+            tmp[cell.data] = true
+        }
+    }
+    return tmp
+})
+
 const formatFunctions = computed(() => {
     const tmp: Record<string, (...args: any[]) => any> = {}
     for (const cell of props.header) {
@@ -426,10 +436,15 @@ const filteredData = computed<TRowData[]>(() => {
             if (filter.value.hasOwnProperty(index) && filter.value[index] !== '' && filter.value[index]) {
                 if (filterFunctions.value.hasOwnProperty(index) && typeof filterFunctions.value[index] === 'function') {
                     isVisible = isVisible && filterFunctions.value[index](`${row[index]}`, filter.value[index], row)
-                } else if (formatFunctions.value[index] && typeof formatFunctions.value[index] === 'function') {
-                    isVisible = isVisible && `${formatFunctions.value[index](row[index], row)}`.includes(filter.value[index])
                 } else {
-                    isVisible = isVisible && `${row[index]}`.toLocaleLowerCase().includes(`${filter.value[index]}`.toLocaleLowerCase())
+                    const caseSensitive = caseSensitiveFilters.value[index] === true
+                    const cellValue = (formatFunctions.value[index] && typeof formatFunctions.value[index] === 'function')
+                        ? `${formatFunctions.value[index](row[index], row)}`
+                        : `${row[index]}`
+                    const needle = `${filter.value[index]}`
+                    isVisible = isVisible && (caseSensitive
+                        ? cellValue.includes(needle)
+                        : cellValue.toLocaleLowerCase().includes(needle.toLocaleLowerCase()))
                 }
                 if (!isVisible) {
                     return false

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -26,6 +26,7 @@ export interface ColumnDefinition<
     data: DotPaths<T>
     sortable?: boolean
     filterable?: boolean
+    filterCaseSensitive?: boolean
     format?: (value: any, row: ProcessedRowData<T>) => any
     sortFn?: (a: any, b: any) => number
     filterFn?: (cellValue: any, filterValue: string, rowData: ProcessedRowData<T>) => boolean


### PR DESCRIPTION
Introduce a new option for case-sensitive filtering in the data table, allowing users to specify whether the filter should consider case when matching values.